### PR TITLE
Modify `Response.content` to be of type bytes

### DIFF
--- a/hrequests/response.py
+++ b/hrequests/response.py
@@ -287,4 +287,5 @@ def build_response(res: Union[dict, list], res_cookies: RequestsCookieJar) -> Re
         cookies=res_cookies,
         # add response body
         _text=res["body"],
+        _content=res["content"] if "content" in res else None,
     )


### PR DESCRIPTION
## Description

As discussed in https://github.com/daijro/hrequests/issues/31 and https://github.com/daijro/hrequests/issues/24, `hrequests.get()` returns both `request.text` and `request.content` as identical `str` objects due to this conversion: https://github.com/bogdanfinn/tls-client/blob/e09a70ebbd208feab47f2bf05a10bdd74be5f142/cffi_src/factory.go#L213C30-L213C30

From what I can see, this could be resolved in one of two ways:

* Modifying `factory.go` to return both the `bytes` and `str` objects
* Making use of the [readAllBodyWithStreamToFile](https://github.com/bogdanfinn/tls-client/blob/e09a70ebbd208feab47f2bf05a10bdd74be5f142/cffi_src/factory.go#L143C6-L184) function to output an intermediate file containing the `bytes` text data, then reading file that and populating `request.content` with the `bytes` data

I don't have enough experience in Go to know how easy the first option would be, so here I propose a Python-based fix that, while ugly (creating a `tempfile` to write/read from), gets the job done.


### Sample Code

Input:

```python
import hrequests
r = hrequests.get("https://bbc.com")
print(r)
print(type(r.text))
print(type(r.content))
```

Output:

```python
<Response [200]>
<class 'str'>
<class 'bytes'>
```
