### PR TITLE
Update pyproject.toml: Froce `browserforge>=1.2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-browserforge = "1.1.2"
+browserforge = "^1.2.1"
 ua_parser = "*"
 orjson = "*"
 httpx = "*"


### PR DESCRIPTION
Froce `browserforge>=1.2.1`, because `Camoufox` pythonlib force depends on `browserforge>=1.1.2`

Reference issue:
https://github.com/daijro/browserforge/issues/17