### PR TITLE
Handle cookies dict set to prevent AttributeError

### DIFF
--- a/hrequests/client.py
+++ b/hrequests/client.py
@@ -327,7 +327,7 @@ class TLSClient:
         elif isinstance(cookies, list):
             merge_cookies(self.cookies, list_to_cookiejar(cookies))
         elif isinstance(cookies, dict):
-            self.cookies.set_cookie(cookiejar_from_dict(cookies))
+            merge_cookies(self.cookies, cookiejar_from_dict(cookies))
 
         # turn cookie jar into dict
 


### PR DESCRIPTION
Use merge_cookies instead of individual set_cookie calls when handling dictionary cookies. This ensures:
- Consistent behavior across all cookie types (dict, list, RequestsCookieJar)
- Better handling of cookie merging and potential conflicts
- Proper domain and path handling through merge_cookies function

Open issue: [https://github.com/daijro/hrequests/issues/90](https://github.com/daijro/hrequests/issues/90)